### PR TITLE
Avoid ConcurrentModification exceptions when running with JDK11

### DIFF
--- a/apt-utils/src/main/java/com/slimgears/apt/data/TypeInfo.java
+++ b/apt-utils/src/main/java/com/slimgears/apt/data/TypeInfo.java
@@ -266,9 +266,15 @@ public abstract class TypeInfo implements HasName, HasEnclosingType, HasAnnotati
     }
 
     private static TypeInfo register(TypeInfo type) {
-        typeRegistrar.current().computeIfAbsent(type.erasureName(), tname -> type.hasTypeParams() ? TypeInfo.of(tname) : type);
-        if (!type.hasEnclosingType() && typeRegistrar.current().containsKey(packageName(type.erasureName()))) {
-            return type.toBuilder().enclosingType(typeRegistrar.current().get(packageName(type.erasureName()))).build();
+        String erasureName = type.erasureName();
+        if (typeRegistrar.current().get(erasureName) == null) {
+            TypeInfo newValue = type.hasTypeParams() ? TypeInfo.of(erasureName) : type;
+            if (newValue != null) {
+                typeRegistrar.current().put(erasureName, newValue);
+            }
+        }
+        if (!type.hasEnclosingType() && typeRegistrar.current().containsKey(packageName(erasureName))) {
+            return type.toBuilder().enclosingType(typeRegistrar.current().get(packageName(erasureName))).build();
         }
         return type;
     }


### PR DESCRIPTION
Pushing again a fix that was already fixed in the past.